### PR TITLE
Additionally check ProcessName in handleLoadPackage()

### DIFF
--- a/src/com/germainz/activityforcenewtask/XposedMod.java
+++ b/src/com/germainz/activityforcenewtask/XposedMod.java
@@ -22,7 +22,7 @@ public class XposedMod implements IXposedHookLoadPackage {
 
     @Override
     public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
-        if (!lpparam.packageName.equals("android"))
+        if ((!lpparam.packageName.equals("android")) || (!lpparam.processName.equals("android")))
             return;
 
         XC_MethodHook hook = new XC_MethodHook() {


### PR DESCRIPTION
In Lollipop other processes run with the "android" package name. To fix this check for the process name as well.
@rovo89 confirmed the issue and promised an update which will probably change the package name for those processes to "system", until then both checks should be used or the subsequent hooks are going to fail and throw an exception.
