### PR TITLE
Android 10 compatibility

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,11 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.germainz.activityforcenewtask"
-          android:versionCode="24"
-          android:versionName="2.1.3">
+          android:versionCode="25"
+          android:versionName="2.1.4">
 
     <uses-sdk
             android:minSdkVersion="11"
-            android:targetSdkVersion="19"/>
+            android:targetSdkVersion="28"/>
 
     <application
             android:icon="@drawable/ic_launcher"

--- a/src/com/germainz/activityforcenewtask/XposedMod.java
+++ b/src/com/germainz/activityforcenewtask/XposedMod.java
@@ -54,7 +54,7 @@ public class XposedMod implements IXposedHookLoadPackage {
                 if (getIntField(param.thisObject, "launchedFromUid") == uid)
                     return;
 
-                ComponentName componentName = (ComponentName) getObjectField(param.thisObject, "realActivity");
+                ComponentName componentName = (ComponentName) getObjectField(param.thisObject, "mActivityComponent");
                 String componentNameString = componentName.flattenToString();
                 // Log if necessary.
                 if (settingsHelper.isLogEnabled()) {
@@ -81,7 +81,7 @@ public class XposedMod implements IXposedHookLoadPackage {
             }
         };
 
-        Class ActivityRecord = findClass("com.android.server.am.ActivityRecord", lpparam.classLoader);
+        Class ActivityRecord = findClass("com.android.server.wm.ActivityRecord", lpparam.classLoader);
         XposedBridge.hookAllConstructors(ActivityRecord, hook);
     }
 


### PR DESCRIPTION
Android 10 has moved ActivityRecord from .am. to .wm. and renamed a variable, thus the hooks need to be changed.
Note that this commit will be Android 10 only and breaks compatibility with older versions